### PR TITLE
Fix CLI needing a graphical environment to work

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -46,8 +46,9 @@ struct Arguments {
         }
 
         if (args.size() > 1) {
-            qWarning() << QApplication::translate(
-                "main", "Too many positional arguments given. Only the first one is used.");
+            qCritical() << QApplication::translate(
+                "main", "Too many positional arguments given. Only one input file is supported.");
+            exit(1);
         }
 
         instance.url =

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -153,11 +153,11 @@ static void loadInitialSound(QQmlApplicationEngine* engine, const QUrl& url) {
 }
 
 int main(int argc, char* argv[]) {
-    QCoreApplication cli(argc, argv);
+    auto cli = std::make_unique<QCoreApplication>(argc, argv);
 
     QCommandLineParser parser;
     setupCommandLineParser(&parser);
-    parser.process(cli);
+    parser.process(*cli.get());
 
     registerQmlTypes();
 
@@ -166,7 +166,7 @@ int main(int argc, char* argv[]) {
         return exportSound(maybeArgs.value());
     }
 
-    cli.~QCoreApplication();
+    cli.reset();
 
     QApplication app(argc, argv);
     Q_INIT_RESOURCE(qml);

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -152,22 +152,25 @@ static void loadInitialSound(QQmlApplicationEngine* engine, const QUrl& url) {
 }
 
 int main(int argc, char* argv[]) {
+    QCoreApplication cli(argc, argv);
+
+    QCommandLineParser parser;
+    setupCommandLineParser(&parser);
+    parser.process(*qApp);
+
+    registerQmlTypes();
+
+    auto maybeArgs = Arguments::parse(parser);
+    if (maybeArgs.has_value() && maybeArgs.value().export_) {
+        return exportSound(maybeArgs.value());
+    }
+
     QApplication app(argc, argv);
     Q_INIT_RESOURCE(qml);
     app.setOrganizationDomain("agateau.com");
     app.setApplicationName("sfxr-qt");
     app.setApplicationDisplayName("SFXR Qt");
     app.setWindowIcon(createIcon());
-    registerQmlTypes();
-
-    QCommandLineParser parser;
-    setupCommandLineParser(&parser);
-    parser.process(*qApp);
-
-    auto maybeArgs = Arguments::parse(parser);
-    if (maybeArgs.has_value() && maybeArgs.value().export_) {
-        return exportSound(maybeArgs.value());
-    }
 
     QQmlApplicationEngine engine;
     engine.load(QUrl(QStringLiteral("qrc:/main.qml")));

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[]) {
 
     QCommandLineParser parser;
     setupCommandLineParser(&parser);
-    parser.process(*qApp);
+    parser.process(cli);
 
     registerQmlTypes();
 
@@ -165,6 +165,8 @@ int main(int argc, char* argv[]) {
     if (maybeArgs.has_value() && maybeArgs.value().export_) {
         return exportSound(maybeArgs.value());
     }
+
+    cli.~QCoreApplication();
 
     QApplication app(argc, argv);
     Q_INIT_RESOURCE(qml);

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -35,14 +35,24 @@ struct Arguments {
     static optional<Arguments> parse(const QCommandLineParser& parser) {
         Arguments instance;
         auto args = parser.positionalArguments();
+        instance.export_ = parser.isSet("export");
+
         if (args.isEmpty()) {
+            if (instance.export_) {
+                qCritical() << QApplication::translate("main", "No file given to export.");
+                exit(1);
+            }
             return {};
+        }
+
+        if (args.size() > 1) {
+            qWarning() << QApplication::translate(
+                "main", "Too many positional arguments given. Only the first one is used.");
         }
 
         instance.url =
             QUrl::fromUserInput(args.first(), QDir::currentPath(), QUrl::AssumeLocalFile);
 
-        instance.export_ = parser.isSet("export");
         if (!instance.export_) {
             return instance;
         }


### PR DESCRIPTION
Closes #11 by using a QCoreApplication to process the arguments.
This least hacky solution I could come up with. This way --help and possible future options will work too.
As a bonus, a few more error messages for incorrect CLI usage are included.