### PR TITLE
header file missing

### DIFF
--- a/src/ui/SoundPreview.cpp
+++ b/src/ui/SoundPreview.cpp
@@ -3,6 +3,7 @@
 #include "Sound.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QtConcurrent>
 
 static const QColor WAVE_BORDER_COLOR = Qt::white;


### PR DESCRIPTION
error: aggregate 'QPainterPath path' has incomplete type and cannot be defined