### PR TITLE
Add an option to use the system provided catch2 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,11 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 
 # Source dirs
-add_subdirectory(3rdparty/catch2)
+if (USE_SYSTEM_CATCH2)
+   find_package(Catch2 REQUIRED)
+else()
+    add_subdirectory(3rdparty/catch2)
+endif()
 add_subdirectory(src)
 if (BUILD_TESTING)
     enable_testing() # must come *before* adding tests directory


### PR DESCRIPTION
While updating https://aur.archlinux.org/packages/sfxr-qt the 4-year-old catch2 added via submodule is a blocker because it does not compile anymore. This adds an option to use the pre-built https://archlinux.org/packages/extra/any/catch2/ instead.