### PR TITLE
Port to catch3

### DIFF
--- a/tests/SoundTest.cpp
+++ b/tests/SoundTest.cpp
@@ -9,7 +9,7 @@
 #include <QTemporaryDir>
 #include <QUrl>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 static bool fuzzyEq(const Sound& s1, const Sound& s2) {
     QMetaObject mo = BaseSound::staticMetaObject;
@@ -19,7 +19,7 @@ static bool fuzzyEq(const Sound& s1, const Sound& s2) {
         QVariant v2 = property.read(&s2);
 
         if (property.type() == QVariant::Double) {
-            if (v1.toDouble() != Approx(v2.toDouble())) {
+            if (v1.toDouble() != Catch::Approx(v2.toDouble())) {
                 return false;
             }
         } else {
@@ -38,9 +38,9 @@ TEST_CASE("Sound") {
         auto path = QUrl::fromLocalFile(QString(TEST_FIXTURES_DIR) + "/pickup.sfxr");
         REQUIRE(sound.load(path));
         CHECK(sound.waveForm() == 0);
-        CHECK(sound.sustainTime() == Approx(0.05916));
-        CHECK(sound.baseFrequency() == Approx(0.5019));
-        CHECK(sound.changeSpeed() == Approx(0.54938));
+        CHECK(sound.sustainTime() == Catch::Approx(0.05916));
+        CHECK(sound.baseFrequency() == Catch::Approx(0.5019));
+        CHECK(sound.changeSpeed() == Catch::Approx(0.54938));
         CHECK(sound.phaserOffset() == 0);
     }
 
@@ -49,9 +49,9 @@ TEST_CASE("Sound") {
         auto path = QUrl::fromLocalFile(QString(TEST_FIXTURES_DIR) + "/pickup.sfxj");
         REQUIRE(sound.load(path));
         CHECK(sound.waveForm() == 0);
-        CHECK(sound.sustainTime() == Approx(0.05916));
-        CHECK(sound.baseFrequency() == Approx(0.5019));
-        CHECK(sound.changeSpeed() == Approx(0.54938));
+        CHECK(sound.sustainTime() == Catch::Approx(0.05916));
+        CHECK(sound.baseFrequency() == Catch::Approx(0.5019));
+        CHECK(sound.changeSpeed() == Catch::Approx(0.54938));
         CHECK(sound.phaserOffset() == 0);
     }
 

--- a/tests/SoundTest.cpp
+++ b/tests/SoundTest.cpp
@@ -11,6 +11,15 @@
 
 #include <catch2/catch_all.hpp>
 
+using Catch::Matchers::Equals;
+using Catch::Matchers::WithinAbs;
+
+static constexpr double PRECISION = 0.00001;
+
+static auto Within(float value) {
+    return WithinAbs(value, PRECISION);
+}
+
 static bool fuzzyEq(const Sound& s1, const Sound& s2) {
     QMetaObject mo = BaseSound::staticMetaObject;
     for (int i = 0; i < mo.propertyCount(); ++i) {
@@ -19,7 +28,7 @@ static bool fuzzyEq(const Sound& s1, const Sound& s2) {
         QVariant v2 = property.read(&s2);
 
         if (property.type() == QVariant::Double) {
-            if (v1.toDouble() != Catch::Approx(v2.toDouble())) {
+            if (qAbs(v1.toDouble() - v2.toDouble()) > PRECISION) {
                 return false;
             }
         } else {
@@ -37,10 +46,12 @@ TEST_CASE("Sound") {
         Sound sound;
         auto path = QUrl::fromLocalFile(QString(TEST_FIXTURES_DIR) + "/pickup.sfxr");
         REQUIRE(sound.load(path));
-        CHECK(sound.waveForm() == 0);
-        CHECK(sound.sustainTime() == Catch::Approx(0.05916));
-        CHECK(sound.baseFrequency() == Catch::Approx(0.5019));
-        CHECK(sound.changeSpeed() == Catch::Approx(0.54938));
+        CHECK(sound.waveForm() == WaveForm::Enum::Square);
+        CHECK_THAT(sound.sustainTime(), Within(0.05916));
+        CHECK_THAT(sound.sustainTime(), Within(0.05916));
+        CHECK_THAT(sound.sustainTime(), Within(0.05916));
+        CHECK_THAT(sound.baseFrequency(), Within(0.5019));
+        CHECK_THAT(sound.changeSpeed(), Within(0.54938));
         CHECK(sound.phaserOffset() == 0);
     }
 
@@ -48,10 +59,10 @@ TEST_CASE("Sound") {
         Sound sound;
         auto path = QUrl::fromLocalFile(QString(TEST_FIXTURES_DIR) + "/pickup.sfxj");
         REQUIRE(sound.load(path));
-        CHECK(sound.waveForm() == 0);
-        CHECK(sound.sustainTime() == Catch::Approx(0.05916));
-        CHECK(sound.baseFrequency() == Catch::Approx(0.5019));
-        CHECK(sound.changeSpeed() == Catch::Approx(0.54938));
+        CHECK(sound.waveForm() == WaveForm::Enum::Square);
+        CHECK_THAT(sound.sustainTime(), Within(0.05916));
+        CHECK_THAT(sound.baseFrequency(), Within(0.5019));
+        CHECK_THAT(sound.changeSpeed(), Within(0.54938));
         CHECK(sound.phaserOffset() == 0);
     }
 

--- a/tests/SoundTest.cpp
+++ b/tests/SoundTest.cpp
@@ -9,7 +9,8 @@
 #include <QTemporaryDir>
 #include <QUrl>
 
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 
 using Catch::Matchers::Equals;
 using Catch::Matchers::WithinAbs;

--- a/tests/SynthesizerTest.cpp
+++ b/tests/SynthesizerTest.cpp
@@ -9,7 +9,7 @@
 #include <QDir>
 #include <QTemporaryDir>
 
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 static constexpr char FIXTURES_DIR[] = TEST_FIXTURES_DIR "/synthesizer";
 

--- a/tests/SynthesizerTest.cpp
+++ b/tests/SynthesizerTest.cpp
@@ -9,7 +9,7 @@
 #include <QDir>
 #include <QTemporaryDir>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 static constexpr char FIXTURES_DIR[] = TEST_FIXTURES_DIR "/synthesizer";
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -3,7 +3,8 @@
 #include <QCoreApplication>
 #include <QtTest>
 
-#include <catch2/catch_all.hpp>
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,10 +1,9 @@
-#define CATCH_CONFIG_RUNNER
 #include "SynthesizerTest.h"
 
 #include <QCoreApplication>
 #include <QtTest>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);


### PR DESCRIPTION
- Port to Catch 3.4.0
- Remove use of Catch::Approx
- Do not use catch_all.hpp

This should help packagers (see #16).