### PR TITLE
Fix rendering of very short sounds

### DIFF
--- a/src/ui/SoundPreview.cpp
+++ b/src/ui/SoundPreview.cpp
@@ -54,7 +54,7 @@ struct MinMax {
 
 static MinMax computeMinMax(const QVector<qreal>& samples, qreal from, qreal to) {
     int fromIdx = from * samples.length();
-    int toIdx = to * samples.length();
+    int toIdx = qMax(int(to * samples.length()), fromIdx + 1);
     MinMax minMax;
     for (int idx = fromIdx; idx < toIdx; ++idx) {
         auto volume = samples[idx];
@@ -140,6 +140,9 @@ void SoundPreview::updatePreview() {
     }
 
     auto samples = mSoundPlayer->samples();
+    if (samples.isEmpty()) {
+        return;
+    }
     QFuture<QImage> future = QtConcurrent::run(generatePreviewImage, samples, width(), height());
     mPreviewWatcher->setFuture(future);
 }


### PR DESCRIPTION
If the sound is short enough, computeMinMax() for loop would not run at
all because fromIdx == toIdx, causing it to return a MinMax initialized
to the default value.

Force toIdx to be at least fromIdx + 1 to avoid that.

Fixes #21
